### PR TITLE
Fixed bug: uninitialized local variable

### DIFF
--- a/opennn/model_selection.cpp
+++ b/opennn/model_selection.cpp
@@ -981,7 +981,7 @@ ModelSelection::ModelSelectionResults ModelSelection::perform_order_selection(vo
 
 #endif
 
-    ModelSelectionResults results;
+	ModelSelectionResults results = {};
 
     switch(order_selection_type)
     {

--- a/tests/golden_section_order_test.cpp
+++ b/tests/golden_section_order_test.cpp
@@ -123,7 +123,7 @@ void GoldenSectionOrderTest::test_perform_order_selection(void)
     ds.set(data);
 
     uses.set(21,Instances::Training);
-    for (size_t i = 0; i < 11; i++)
+    for (size_t i = 0; i < 10; i++)
         uses[2*i+1] = Instances::Selection;
 
     ds.get_instances_pointer()->set_uses(uses);
@@ -177,7 +177,7 @@ void GoldenSectionOrderTest::test_perform_order_selection(void)
     ds.set(data);
 
     uses.set(21,Instances::Training);
-    for (size_t i = 0; i < 11; i++)
+    for (size_t i = 0; i < 10; i++)
         uses[2*i+1] = Instances::Selection;
 
     ds.get_instances_pointer()->set_uses(uses);

--- a/tests/incremental_order_test.cpp
+++ b/tests/incremental_order_test.cpp
@@ -123,7 +123,7 @@ void IncrementalOrderTest::test_perform_order_selection(void)
     ds.set(data);
 
     uses.set(21,Instances::Training);
-    for (size_t i = 0; i < 11; i++)
+    for (size_t i = 0; i < 10; i++)
         uses[2*i+1] = Instances::Selection;
 
     ds.get_instances_pointer()->set_uses(uses);
@@ -177,7 +177,7 @@ void IncrementalOrderTest::test_perform_order_selection(void)
     ds.set(data);
 
     uses.set(21,Instances::Training);
-    for (size_t i = 0; i < 11; i++)
+    for (size_t i = 0; i < 10; i++)
         uses[2*i+1] = Instances::Selection;
 
     ds.get_instances_pointer()->set_uses(uses);

--- a/tests/simulated_annealing_order_test.cpp
+++ b/tests/simulated_annealing_order_test.cpp
@@ -123,7 +123,7 @@ void SimulatedAnnealingOrderTest::test_perform_order_selection(void)
     ds.set(data);
 
     uses.set(21,Instances::Training);
-    for (size_t i = 0; i < 11; i++)
+    for (size_t i = 0; i < 10; i++)
         uses[2*i+1] = Instances::Selection;
 
     ds.get_instances_pointer()->set_uses(uses);
@@ -177,7 +177,7 @@ void SimulatedAnnealingOrderTest::test_perform_order_selection(void)
     ds.set(data);
 
     uses.set(21,Instances::Training);
-    for (size_t i = 0; i < 11; i++)
+    for (size_t i = 0; i < 10; i++)
         uses[2*i+1] = Instances::Selection;
 
     ds.get_instances_pointer()->set_uses(uses);


### PR DESCRIPTION
Leaving this local variable uninitialized makes examples crash with Visual Studio 2015 Update 3.