### PR TITLE
add option to skip building examples and tests (default: not skip)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,10 +28,18 @@ endif()
 # Uncomment next line to compile without using C++11
 #add_definitions(-D__Cpp11__)
 
+option(OpenNN_BUILD_EXAMPLES "Build OpenNN examples" ON)
+option(OpenNN_BUILD_TESTS    "Build OpenNN tests"    ON)
+
 add_subdirectory(opennn)
 include_directories(opennn)
-add_subdirectory(examples)
-add_subdirectory(blank)
-add_subdirectory(tests)
+
+if(OpenNN_BUILD_TESTS)
+    add_subdirectory(tests)
+endif(OpenNN_BUILD_TESTS)
+
+if(OpenNN_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif(OpenNN_BUILD_EXAMPLES)
 
 include(CPack)


### PR DESCRIPTION
### New Feature
Add options to skip building examples and tests.  Default behaviour is not changed.

### How to use
- To skip building examples: set `-DOpenNN_BUILD_EXAMPLES=OFF`
- To skip building tests: set `-DOpenNN_BUILD_TESTS=OFF`
- To skip both: set both options

### Others
Remove `blank` directory from the build tree since it seems just a template for new project.