### PR TITLE
examples cmake linking fix

### DIFF
--- a/examples/airfoil_self_noise/CMakeLists.txt
+++ b/examples/airfoil_self_noise/CMakeLists.txt
@@ -6,14 +6,12 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(airfoil_self_noise)
 
-set (PROJECT_LINK_LIBS ../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(airfoil_self_noise main.cpp)
 
-target_link_libraries(airfoil_self_noise ${PROJECT_LINK_LIBS})
+target_link_libraries(airfoil_self_noise opennn)
 
 

--- a/examples/airline_passengers/CMakeLists.txt
+++ b/examples/airline_passengers/CMakeLists.txt
@@ -6,14 +6,12 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(airline_passengers)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(airline_passengers main.cpp)
 
-target_link_libraries(airline_passengers ${PROJECT_LINK_LIBS})
+target_link_libraries(airline_passengers opennn)
 
 

--- a/examples/breast_cancer/CMakeLists.txt
+++ b/examples/breast_cancer/CMakeLists.txt
@@ -6,14 +6,12 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(breast_cancer)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(breast_cancer main.cpp)
 
-target_link_libraries(breast_cancer ${PROJECT_LINK_LIBS})
+target_link_libraries(breast_cancer opennn)
 
 

--- a/examples/iris_plant/CMakeLists.txt
+++ b/examples/iris_plant/CMakeLists.txt
@@ -6,15 +6,13 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(iris_plant)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(iris_plant main.cpp)
 
-target_link_libraries(iris_plant ${PROJECT_LINK_LIBS})
+target_link_libraries(iris_plant opennn)
 
 
 

--- a/examples/leukemia/CMakeLists.txt
+++ b/examples/leukemia/CMakeLists.txt
@@ -6,13 +6,11 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(leukemia)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(leukemia main.cpp)
 
-target_link_libraries(leukemia ${PROJECT_LINK_LIBS})
+target_link_libraries(leukemia opennn)
 

--- a/examples/logical_operations/CMakeLists.txt
+++ b/examples/logical_operations/CMakeLists.txt
@@ -6,13 +6,11 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(logical_operations)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(logical_operations main.cpp)
 
-target_link_libraries(logical_operations ${PROJECT_LINK_LIBS})
+target_link_libraries(logical_operations opennn)
 

--- a/examples/mnist/CMakeLists.txt
+++ b/examples/mnist/CMakeLists.txt
@@ -6,14 +6,12 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(mnist)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(mnist main.cpp)
 
-target_link_libraries(mnist ${PROJECT_LINK_LIBS})
+target_link_libraries(mnist opennn)
 
 

--- a/examples/pima_indians_diabetes/CMakeLists.txt
+++ b/examples/pima_indians_diabetes/CMakeLists.txt
@@ -4,14 +4,12 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(pima_indians_diabetes)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(pima_indians_diabetes main.cpp)
 
-target_link_libraries(pima_indians_diabetes ${PROJECT_LINK_LIBS})
+target_link_libraries(pima_indians_diabetes opennn)
 
 

--- a/examples/pollution_forecasting/CMakeLists.txt
+++ b/examples/pollution_forecasting/CMakeLists.txt
@@ -4,14 +4,12 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(pollution_forecasting)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(pollution_forecasting main.cpp)
 
-target_link_libraries(pollution_forecasting ${PROJECT_LINK_LIBS})
+target_link_libraries(pollution_forecasting opennn)
 
 

--- a/examples/simple_function_regression/CMakeLists.txt
+++ b/examples/simple_function_regression/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(simple_function_regression)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(simple_function_regression main.cpp)
 
-target_link_libraries(simple_function_regression ${PROJECT_LINK_LIBS})
+target_link_libraries(simple_function_regression opennn)
 

--- a/examples/simple_pattern_recognition/CMakeLists.txt
+++ b/examples/simple_pattern_recognition/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(simple_pattern_recognition)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(simple_pattern_recognition main.cpp)
 
-target_link_libraries(simple_pattern_recognition ${PROJECT_LINK_LIBS})
+target_link_libraries(simple_pattern_recognition opennn)
 

--- a/examples/temperature_forecasting/CMakeLists.txt
+++ b/examples/temperature_forecasting/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(temperature_forecasting)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(temperature_forecasting main.cpp)
 
-target_link_libraries(temperature_forecasting ${PROJECT_LINK_LIBS})
+target_link_libraries(temperature_forecasting opennn)
 

--- a/examples/urinary_inflammations_diagnosis/CMakeLists.txt
+++ b/examples/urinary_inflammations_diagnosis/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(urinary_inflammations_diagnosis)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(urinary_inflammations_diagnosis main.cpp)
 
-target_link_libraries(urinary_inflammations_diagnosis ${PROJECT_LINK_LIBS})
+target_link_libraries(urinary_inflammations_diagnosis opennn)
 

--- a/examples/yacht_hydrodynamics_design/CMakeLists.txt
+++ b/examples/yacht_hydrodynamics_design/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(yacht_hydrodynamics_design)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(yacht_hydrodynamics_design main.cpp)
 
-target_link_libraries(yacht_hydrodynamics_design ${PROJECT_LINK_LIBS})
+target_link_libraries(yacht_hydrodynamics_design opennn)
 

--- a/examples/yacht_hydrodynamics_production/CMakeLists.txt
+++ b/examples/yacht_hydrodynamics_production/CMakeLists.txt
@@ -4,13 +4,11 @@ cmake_minimum_required(VERSION 2.8.10)
 
 project(yacht_hydrodynamics_production)
 
-set (PROJECT_LINK_LIBS ../../opennn/Release/opennn)
-
 link_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 include_directories(${CMAKE_SOURCE_DIR}/opennn)
 
 add_executable(yacht_hydrodynamics_production main.cpp)
 
-target_link_libraries(yacht_hydrodynamics_production ${PROJECT_LINK_LIBS})
+target_link_libraries(yacht_hydrodynamics_production opennn)
 


### PR DESCRIPTION
I could only launch `pollution_forecasting` and get

```
Segmentation fault
```

This error is irrelevant to library linking so I think pull request is worth considering. 