### PR TITLE
Suggestion to allow treating datetime data as numeric

### DIFF
--- a/opennn/data_set.cpp
+++ b/opennn/data_set.cpp
@@ -5521,7 +5521,7 @@ Tensor<CorrelationResults, 2> DataSet::calculate_input_target_columns_correlatio
 
             cout << "Calculating " << columns(input_index).name << " - " << columns(target_index).name << " correlations. \n" ;
 
-            if(input_type == Numeric && target_type == Numeric)
+            if((input_type == Numeric || input_type == DateTime) && target_type == Numeric)
             {
                 const TensorMap<Tensor<type,1>> input_column(input.data(), input.dimension(0));
                 const TensorMap<Tensor<type,1>> target_column(target.data(), target.dimension(0));
@@ -5553,7 +5553,7 @@ Tensor<CorrelationResults, 2> DataSet::calculate_input_target_columns_correlatio
 
 //                correlations(i,j) = karl_pearson_correlations(thread_pool_device, input, target);
             }
-            else if(input_type == Numeric && target_type == Binary)
+            else if((input_type == Numeric || input_type == DateTime) && target_type == Binary)
             {
                 const TensorMap<Tensor<type,1>> input_column(input.data(), input.dimension(0));
                 const TensorMap<Tensor<type,1>> target_column(target.data(), target.dimension(0));
@@ -5573,7 +5573,7 @@ Tensor<CorrelationResults, 2> DataSet::calculate_input_target_columns_correlatio
 
                 correlations(i,j) = multiple_logistic_correlations(thread_pool_device, input, target/*target_column*/);
             }
-            else if(input_type == Numeric && target_type == Categorical)
+            else if((input_type == Numeric || input_type == DateTime) && target_type == Categorical)
             {
                 const TensorMap<Tensor<type,1>> input_column(input.data(), input.dimension(0));
 

--- a/opennn/opennn_strings.cpp
+++ b/opennn/opennn_strings.cpp
@@ -90,7 +90,7 @@ Tensor<string, 1> get_tokens(const string& str, const char& separator)
     while(string::npos != pos || string::npos != lastPos)
     {
 
-        if((lastPos-old_pos != 1) && index!= 0){
+        if(index != 0 && (lastPos-old_pos != 1)){
             tokens[index] = "";
             index++;
             old_pos = old_pos+1;
@@ -142,7 +142,7 @@ void fill_tokens(const string& str, const char& separator, Tensor<string, 1>& to
     {
         // Found a token, add it to the vector
 
-        if((last_position-old_pos != 1) && index!= 0)
+        if(index != 0 && (last_position-old_pos != 1))
         {
             tokens[index] = "";
             index++;


### PR DESCRIPTION
Some datasets contain datetime data which is correlated to the target data (i.e. target 'housing prices' reliant on input 'year built'). It would be useful to be allow correlation calculation for such data.