### PR TITLE
Consistency changes

### DIFF
--- a/opennn/data_set.cpp
+++ b/opennn/data_set.cpp
@@ -3524,10 +3524,7 @@ Tensor<type, 2> DataSet::get_selection_data() const
 {
     const Tensor<Index, 1> selection_indices = get_selection_samples_indices();
 
-    const Index variables_number = get_variables_number();
-
-    Tensor<Index, 1> variables_indices;
-    initialize_sequential_eigen_tensor(variables_indices, 0, 1, variables_number-1);
+    const Tensor<Index, 1> variables_indices = get_used_variables_indices();
 
     return get_subtensor_data(selection_indices, variables_indices);
 }
@@ -3539,10 +3536,7 @@ Tensor<type, 2> DataSet::get_selection_data() const
 
 Tensor<type, 2> DataSet::get_testing_data() const
 {
-    const Index variables_number = get_variables_number();
-
-    Tensor<Index, 1> variables_indices;
-    initialize_sequential_eigen_tensor(variables_indices, 0, 1, variables_number-1);
+    const Tensor<Index, 1> variables_indices = get_used_variables_indices();
 
     const Tensor<Index, 1> testing_indices = get_testing_samples_indices();
 
@@ -3556,10 +3550,7 @@ Tensor<type, 2> DataSet::get_testing_data() const
 
 Tensor<type, 2> DataSet::get_input_data() const
 {
-    const Index samples_number = get_samples_number();
-
-    Tensor<Index, 1> indices;
-    initialize_sequential_eigen_tensor(indices, 0, 1, samples_number-1);
+    const Tensor<Index, 1> indices = get_used_samples_indices();
 
     const Tensor<Index, 1> input_variables_indices = get_input_variables_indices();
 

--- a/opennn/data_set.cpp
+++ b/opennn/data_set.cpp
@@ -1852,6 +1852,19 @@ void DataSet::set_column_name(const Index& column_index, const string& new_name)
     columns(column_index).name = new_name;
 }
 
+Tensor<DataSet::ColumnType, 1> DataSet::get_columns_types() const
+{
+    const Index columns_number = get_columns_number();
+
+    Tensor<DataSet::ColumnType, 1> columns_types(columns_number);
+
+    for (size_t i = 0; i < columns_number; i++)
+    {
+        columns_types[i] = columns[i].type;
+    }
+
+    return columns_types;
+}
 
 /// Returns the use of a single variable.
 /// @param index Index of variable.
@@ -4322,6 +4335,8 @@ void DataSet::set(const DataSet& other_data_set)
     columns = other_data_set.columns;
 
     display = other_data_set.display;
+
+    samples_uses = other_data_set.samples_uses;
 }
 
 
@@ -10680,7 +10695,10 @@ void DataSet::read_csv_3_complete()
                 }
                 else
                 {
-                    data(sample_index, variable_index) = static_cast<type>(date_to_timestamp(tokens(j), gmt));
+                    double date = static_cast<type>(date_to_timestamp(tokens[j], gmt));
+                    if (date == -1.0) // TODO: need new solution, currently changes dates before 1970 to 0.
+                        date = 0.0;
+                    data(sample_index, variable_index) = date;
                     variable_index++;
                 }
             }

--- a/opennn/data_set.cpp
+++ b/opennn/data_set.cpp
@@ -8540,6 +8540,71 @@ void DataSet::save_data() const
 }
 
 
+/// Saves to the data file the values of the data matrix.
+
+void DataSet::save_data_to_file(const string& fileName, const char& fileSeperator) const
+{
+    ofstream file(fileName.c_str(), std::ofstream::out | std::ofstream::trunc);
+
+    if (!file.is_open())
+    {
+        ostringstream buffer;
+
+        buffer << "OpenNN Exception: Matrix template." << endl
+            << "void save_csv(const string&, const char&, const Vector<string>&, const Vector<string>&) method." << endl
+            << "Cannot open matrix data file: " << fileName << endl;
+
+        throw logic_error(buffer.str());
+    }
+
+    file.precision(20);
+
+    const Index samples_number = get_samples_number();
+    const Index variables_number = get_variables_number();
+
+    const Tensor<string, 1> variables_names = get_variables_names();
+
+    char separator_char = fileSeperator;
+
+    if (this->has_rows_labels)
+    {
+        file << "id" << separator_char;
+    }
+    for (Index j = 0; j < variables_number; j++)
+    {
+        file << variables_names[j];
+
+        if (j != variables_number - 1)
+        {
+            file << separator_char;
+        }
+    }
+
+    file << endl;
+
+    for (Index i = 0; i < samples_number; i++)
+    {
+        if (this->has_rows_labels)
+        {
+            file << rows_labels(i) << separator_char;
+        }
+        for (Index j = 0; j < variables_number; j++)
+        {
+            file << data(i, j);
+
+            if (j != variables_number - 1)
+            {
+                file << separator_char;
+            }
+        }
+
+        file << endl;
+    }
+
+    file.close();
+}
+
+
 /// Saves to the data file the values of the data matrix in binary format.
 
 void DataSet::save_data_binary(const string& binary_data_file_name) const

--- a/opennn/data_set.h
+++ b/opennn/data_set.h
@@ -251,6 +251,7 @@ public:
    Tensor<Index, 1> get_unused_columns_indices() const;
    Tensor<Index, 1> get_used_columns_indices() const;
 
+   string get_column_name(const Index& index) const {return columns[index].name;}
    Tensor<string, 1> get_columns_names() const;
 
    Tensor<string, 1> get_input_columns_names() const;

--- a/opennn/data_set.h
+++ b/opennn/data_set.h
@@ -258,6 +258,7 @@ public:
    Tensor<string, 1> get_used_columns_names() const;
 
    ColumnType get_column_type(const Index& index) const {return columns[index].type;}
+   Tensor<ColumnType, 1> get_columns_types() const;
 
    VariableUse get_column_use(const Index &) const;
    Tensor<VariableUse, 1> get_columns_uses() const;

--- a/opennn/data_set.h
+++ b/opennn/data_set.h
@@ -717,6 +717,7 @@ public:
    void print_data_file_preview() const;
 
    void save_data() const;
+   void save_data_to_file(const string&, const char&) const;
 
    void save_data_binary(const string&) const;
 

--- a/opennn/opennn_strings.cpp
+++ b/opennn/opennn_strings.cpp
@@ -90,7 +90,7 @@ Tensor<string, 1> get_tokens(const string& str, const char& separator)
     while(string::npos != pos || string::npos != lastPos)
     {
 
-        if((lastPos-old_pos != 1) && index!= 0){
+        if(index != 0 && (lastPos-old_pos != 1)){
             tokens[index] = "";
             index++;
             old_pos = old_pos+1;
@@ -142,7 +142,7 @@ void fill_tokens(const string& str, const char& separator, Tensor<string, 1>& to
     {
         // Found a token, add it to the vector
 
-        if((last_position-old_pos != 1) && index!= 0)
+        if(index != 0 && (last_position-old_pos != 1))
         {
             tokens[index] = "";
             index++;


### PR DESCRIPTION
Column **names**, **types**, and **uses** each have a singular and general get() function.

Initialize data indices with their respective get() functions rather than filling a new Tensor.

'samples_uses' are carried over when setting dataset with existing dataset.

save_data_to_file() function to view dataset after processing in external file.

Set gmt datetimes before 1970 to 0.0 rather than -1.0.