### PR TITLE
Initialise samples_uses when resized

### DIFF
--- a/opennn/data_set.cpp
+++ b/opennn/data_set.cpp
@@ -901,6 +901,7 @@ void DataSet::transform_time_series_data()
     }
 
     samples_uses.resize(new_samples_number);
+    set_training();
 }
 
 
@@ -4645,12 +4646,13 @@ void DataSet::set(const Index& new_samples_number, const Index& new_variables_nu
     columns(new_variables_number-1).type = ColumnType::Numeric;
 
     samples_uses.resize(new_samples_number);
-    split_samples_random();
+    set_training();
 }
 
 
 /// Sets new numbers of samples and inputs and target variables in the data set.
 /// The variables in the data set are the number of inputs plus the number of targets.
+/// All the samples are set for training.
 /// @param new_samples_number Number of
 /// @param new_inputs_number Number of input variables.
 /// @param new_targets_number Number of target variables.
@@ -4687,8 +4689,7 @@ void DataSet::set(const Index& new_samples_number,
     input_variables_dimensions.resize(1);
 
     samples_uses.resize(new_samples_number);
-
-    split_samples_random();
+    set_training();
 }
 
 
@@ -7417,6 +7418,7 @@ void DataSet::from_XML(const tinyxml2::XMLDocument& data_set_document)
         const Index new_samples_number = static_cast<Index>(atoi(samples_number_element->GetText()));
 
         samples_uses.resize(new_samples_number);
+        set_training();
     }
 
     // Samples uses


### PR DESCRIPTION
There's reading of uninitialised memory resulting from `DataSet::samples_uses` not being initialised after resize in a handful of places.  So, I initialised it to training as was already (but inaccurately) commented in one of the methods.  This meant removing a couple calls to split_samples_random.

It looks like the behavior could be different from that comment in other places (split_samples_random rather than all training), so it should probably be normalised to one or the other.  I didn't know which one to pick, seeing them both present, one way in a documentation comment, another way in code.

This PR resolves some valgrind errors.

This PR is made to the dev branch, which is more stable for me.