### PR TITLE
Fix build issues in master

### DIFF
--- a/opennn/embedding_layer.cpp
+++ b/opennn/embedding_layer.cpp
@@ -383,15 +383,19 @@ const Tensor<type, 2> EmbeddingLayer::build_positional_encoding_matrix()
 
     type half_depth = type(depth)/2;
 
-#pragma omp parallel for collapse(2)
+    #pragma omp parallel for collapse(2)
     for(Index i = 0; i < input_length; i++)
     {
-        for(Index j = 0; j < half_depth - 1; j++)
+        for(Index j = 0; j < (int)half_depth - 1; j++)
         {
             positional_encoding_matrix(i, 2*j) = sin( (i + 1) / pow(100000, (j + 1) / half_depth) );
             positional_encoding_matrix(i, 2*j+1) = cos( (i + 1) / pow(100000, (j + 1) / half_depth) );
         }
-
+    }
+    // Fix for collapsed loops not perfectly nested - If statments move to a seperated parallel for
+    #pragma omp parallel for
+    for(Index i = 0; i < input_length; i++)
+    {
         if(depth % 2 == 0)
         {
             positional_encoding_matrix(i, depth - 2) = sin( (i+1) / 10000 );

--- a/opennn/region_proposal_layer.h
+++ b/opennn/region_proposal_layer.h
@@ -101,14 +101,15 @@ struct RegionProposalLayerForwardPropagation : LayerForwardPropagation
         const Index region_columns =  region_proposal_layer_pointer->get_region_columns();
         const Index channels_number =  region_proposal_layer_pointer->get_channels_number();
 
+        // TODO proposal fix to undelclared variables: outputs_data, outputs_dimensions
+        std::vector<type*> outputs_data;
+        std::vector<Tensor<long, 1>> outputs_dimensions;
+
         outputs_data.resize(2);
         outputs_dimensions.resize(2);
 
         // Image patches
-
-        outputs_data.resize(1);
-
-        outputs_data(0) = (type*)malloc(static_cast<size_t>(batch_samples_number*regions_number*region_rows*region_columns*channels_number*sizeof(type)));
+        outputs_data[0] = (type*)malloc(static_cast<size_t>(batch_samples_number*regions_number*region_rows*region_columns*channels_number*sizeof(type)));
 
         outputs_dimensions[0].resize(4);
 
@@ -119,7 +120,7 @@ struct RegionProposalLayerForwardPropagation : LayerForwardPropagation
 
         // Bounding boxes
 
-        outputs_data(1) = (type*)malloc(static_cast<size_t>(1));
+        outputs_data[0] = (type*)malloc(static_cast<size_t>(1));
 
         outputs_dimensions[1].resize(1);
 


### PR DESCRIPTION
This PR touches the following files:

**opennn/region_proposal_layer.h**
Fixed undeclared variables that caused build to fail.

**opennn/embedding_layer.cpp**
Fixed build issue that OpenMP collapsed loops not perfectly nested.
If statements that were in the outer loop were moved to a separated loop.

The following build error was not resolved, it is part of OpenNN tests:
![Screenshot 2024-02-29 at 14 36 10](https://github.com/Artelnics/opennn/assets/18975070/a2d583eb-46c7-4979-b128-ac48c56cf550)

[build_out.txt](https://github.com/Artelnics/opennn/files/14448102/build_out.txt)

