### PR TITLE
Global seed foundation

### DIFF
--- a/opennn/dataset.h
+++ b/opennn/dataset.h
@@ -315,7 +315,8 @@ public:
 
     void split_samples_random(const type& training_ratio = type(0.6),
                               const type& selection_ratio = type(0.2),
-                              const type& testing_ratio = type(0.2));
+                              const type& testing_ratio = type(0.2),
+                              const size_t random_seed = 0);
 
     // Unusing
 

--- a/opennn/dense_layer.cpp
+++ b/opennn/dense_layer.cpp
@@ -9,6 +9,7 @@
 #include "registry.h"
 #include "tensors.h"
 #include "dense_layer.h"
+#include "random.h"
 
 namespace opennn
 {
@@ -1269,10 +1270,10 @@ void Dense2dForwardPropagationCuda::set(const Index& new_batch_size, Layer* new_
     if (dense2d_layer->get_dropout_rate() > type(0))
     {
         {
-            random_device rd;
-            auto now = chrono::high_resolution_clock::now().time_since_epoch().count();
-
-            dropout_seed = (static_cast<unsigned long long>(rd()) << 1) ^ static_cast<unsigned long long>(now);
+            // shift for at least 2 bytes for both 4 byte and 8 byte long integers
+            constexpr uint8_t shift_bits = 16;
+            auto first_half = static_cast<unsigned long long>(getGlobalRandomGenerator()());
+            dropout_seed = (first_half << shift_bits) ^ static_cast<unsigned long long>(getGlobalRandomGenerator()());
         }
         cudnnCreateDropoutDescriptor(&dropout_descriptor);
 

--- a/opennn/image_dataset.cpp
+++ b/opennn/image_dataset.cpp
@@ -139,7 +139,7 @@ void ImageDataset::set_data_random()
         for (Index i = 0; i < samples_number; i++)
         {
             for (Index j = 0; j < inputs_number; j++)
-                data(i, j) = rand() % 255;
+                data(i, j) = getGlobalRandomGenerator()() % 255;
 
             data(i, inputs_number) = (i < half_samples) ? 0 : 1;
         }
@@ -167,7 +167,7 @@ void ImageDataset::set_data_random()
             for (Index i = 0; i < images_number[k]; i++)
             {
                 for (Index j = 0; j < inputs_number; j++)
-                    data(current_sample, j) = rand() % 255;
+                    data(current_sample, j) = getGlobalRandomGenerator()() % 255;
 
                 data(current_sample, k + inputs_number) = 1;
 

--- a/opennn/kmeans.cpp
+++ b/opennn/kmeans.cpp
@@ -8,6 +8,7 @@
 
 #include "tensors.h"
 #include "kmeans.h"
+#include "random.h"
 
 namespace opennn
 {
@@ -225,12 +226,10 @@ void KMeans::set_centers_random(const Tensor<type, 2>& data)
 {
     const Index data_size = data.dimension(0);
 
-    random_device rd;
-    mt19937 gen(rd());
     uniform_int_distribution<> index_distribution(0, data_size - 1);
 
     for(Index i = 0; i < clusters_number; i++)
-        cluster_centers.chip(i, 0) = data.chip(index_distribution(gen), 0);
+        cluster_centers.chip(i, 0) = data.chip(index_distribution(getGlobalRandomGenerator()), 0);
 }
 
 }

--- a/opennn/random.cpp
+++ b/opennn/random.cpp
@@ -1,0 +1,19 @@
+//   OpenNN: Open Neural Networks Library
+//   www.opennn.net
+//
+//   R A N D O M   N U M B E R   G E N E R A T O R   C L A S S
+//
+//   Artificial Intelligence Techniques SL
+//   artelnics@artelnics.com
+#include "random.h"
+
+
+namespace
+{
+    opennn::DefaultRandomGenerator default_generator;
+}
+
+opennn::DefaultRandomGenerator& opennn::getGlobalRandomGenerator()
+{
+    return default_generator;
+}

--- a/opennn/random.h
+++ b/opennn/random.h
@@ -1,0 +1,72 @@
+//   OpenNN: Open Neural Networks Library
+//   www.opennn.net
+//
+//   R A N D O M   N U M B E R   G E N E R A T O R   C L A S S   H E A D E R
+//
+//   Artificial Intelligence Techniques SL
+//   artelnics@artelnics.com
+#include "pch.h"
+
+#ifndef RANDOM_H
+#define RANDOM_H
+
+namespace opennn
+{
+
+
+/// @brief A base generator that satisfies UniformRandomBitGenerator C++11 named requirement.
+/// @todo Use uniform_random_bit_generator concept for C++20 and newer
+class DefaultRandomGenerator
+{
+protected:
+    std::mt19937 generator;
+public:
+    typedef uint32_t result_type;
+
+    static const result_type default_seed = std::mt19937::default_seed;
+
+    DefaultRandomGenerator() : generator(default_seed) {}
+    DefaultRandomGenerator(result_type seed) : generator(seed) {}
+
+    /// @brief Yields the smallest value that operator() may return. The result is strictly less than max().
+    /// @return result_type
+    static constexpr result_type min()
+    {
+        return decltype(generator)::min();
+    }
+
+    /// @brief Yields the largest value that operator() may return. The result is strictly greater than min().
+    /// @return result_type
+    static constexpr result_type max()
+    {
+        return decltype(generator)::max();
+    }
+
+    /// @brief Set a new seed for use in the generator.
+    /// @param new_seed 
+    void seed(result_type new_seed = default_seed)
+    {
+        generator.seed(new_seed);
+    }
+
+    /// @brief Returns the value in the closed interval [min(), max()] in amortized constant time.
+    result_type operator()()
+    {
+        return generator();
+    }
+};
+
+/// @brief Get global RNG object.
+/// @return A reference to the global RNG
+DefaultRandomGenerator& getGlobalRandomGenerator();
+
+/// @brief Set a new seed for use in the global RNG.
+void setGlobalSeed(DefaultRandomGenerator::result_type new_seed = DefaultRandomGenerator::default_seed)
+{
+    getGlobalRandomGenerator().seed(new_seed);
+}
+
+}
+
+
+#endif // RANDOM_H

--- a/opennn/response_optimization.cpp
+++ b/opennn/response_optimization.cpp
@@ -363,7 +363,7 @@ Tensor<type, 2> ResponseOptimization::calculate_inputs() const
             {
                 inputs(i, index) = (input_conditions(index) == ResponseOptimization::Condition::EqualTo)
                     ? input_minimums[index]
-                    : type(rand() % 2);
+                    : type(getGlobalRandomGenerator()() % 2);
 
                 index++;
             }
@@ -386,7 +386,7 @@ Tensor<type, 2> ResponseOptimization::calculate_inputs() const
                 }
 
                 if(equal_index == -1)
-                    inputs(i, index + rand() % categories_number) = type(1);
+                    inputs(i, index + getGlobalRandomGenerator()() % categories_number) = type(1);
 
                 index += categories_number;
             }

--- a/opennn/tensors.cpp
+++ b/opennn/tensors.cpp
@@ -8,6 +8,7 @@
 
 #include "../eigen/Eigen/Dense"
 #include "tensors.h"
+#include "random.h"
 
 namespace opennn
 {
@@ -20,21 +21,15 @@ type bound(const type& value, const type& minimum, const type& maximum)
 
 Index get_random_index(const Index& min, const Index& max)
 {
-    random_device rd;
-    mt19937 gen(rd());
     uniform_int_distribution<> dis(min, max);
-    return dis(gen);
+    return dis(getGlobalRandomGenerator());
 }
 
 
 type get_random_type(const type& minimum, const type& maximum)
 {
-    random_device rd;
-    mt19937 gen(rd());
-
     uniform_real_distribution<type> dis(minimum, maximum);
-
-    return dis(gen);
+    return dis(getGlobalRandomGenerator());
 }
 
 

--- a/opennn/tensors.h
+++ b/opennn/tensors.h
@@ -2,6 +2,7 @@
 #define TENSORS_H
 
 #include "pch.h"
+#include "random.h"
 
 namespace opennn
 {
@@ -125,26 +126,20 @@ bool get_random_bool();
 template<int rank>
 void set_random(Tensor<type, rank>& tensor, const type& minimum = -0.1, const type& maximum = 0.1)
 {
-    random_device rd;
-    mt19937 gen(rd());
-
     uniform_real_distribution<type> distribution(minimum, maximum);
 
     for (Index i = 0; i < tensor.size(); ++i)
-        tensor(i) = distribution(gen);
+        tensor(i) = distribution(getGlobalRandomGenerator());
 }
 
 
 template<int rank>
 void set_random(TensorMap<Tensor<type, rank>>& tensor, const type& minimum = -0.1, const type& maximum = 0.1)
 {
-    random_device rd;
-    mt19937 gen(rd());
-
     uniform_real_distribution<type> distribution(minimum, maximum);
 
     for (Index i = 0; i < tensor.size(); ++i)
-        tensor(i) = distribution(gen);
+        tensor(i) = distribution(getGlobalRandomGenerator());
 }
 
 

--- a/opennn/time_series_dataset.cpp
+++ b/opennn/time_series_dataset.cpp
@@ -788,10 +788,7 @@ vector<vector<Index>> TimeSeriesDataset::get_batches(const vector<Index>& sample
     // @todo copied from dataset
 
     if (!shuffle) return split_samples(sample_indices, batch_size);
-
-    random_device rng;
-    mt19937 urng(rng());
-
+    
     const Index samples_number = sample_indices.size();
 
     const Index batches_number = (samples_number + batch_size - 1) / batch_size;
@@ -800,7 +797,7 @@ vector<vector<Index>> TimeSeriesDataset::get_batches(const vector<Index>& sample
 
     vector<Index> samples_copy(sample_indices);
 
-    std::shuffle(samples_copy.begin(), samples_copy.end(), urng);
+    std::shuffle(samples_copy.begin(), samples_copy.end(), getGlobalRandomGenerator());
 
 #pragma omp parallel for
     for (Index i = 0; i < batches_number; i++)


### PR DESCRIPTION
Hi!

I've recently encountered a problem during training process of our model. The problem itself is not so important (division by zero during back propagation in cross_entropy_error.cpp), because I can see that `dev` branch has changed a lot since the last release version. But I see that what I lacked during debugging has not been addressed yet: reproducibility. Randomization is good, but controlled randomization is even better. Frameworks like PyTorch try to provide ways to reduce the number of nondeterministic behavior. One way is to implement a global RNG, which is what was done in this PR.

The user just has to write something like
```
std::random_device rd;
setGlobalSeed(rd());
```
before using the library.

This is a somewhat "foundational" code, some basic stuff to improve upon in the long run. Now, I don't know the codebase as well as you guys do, so I expect some notes being made and mistakes highlighted, if you will consider this idea.